### PR TITLE
Ensure that the WiFi reconnects if it drops out

### DIFF
--- a/include/Application.h
+++ b/include/Application.h
@@ -20,6 +20,8 @@ private:
     time_t _boot_time;
     time_t _last_update_time;
     time_t _last_transmit_time;
+    time_t _last_wifi_reconnect_time;
+
     AirQualitySensor _sensor;
     Adafruit_BME680 _bme680;
     AsyncWebServer _server;

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -31,6 +31,11 @@
 #define AIR_QUALITY_SENSOR_UPDATE_SECONDS   2
 #endif
 
+// Defines the delay between repeated attempts to reconnect to Wifi access point.
+#ifndef AIR_QUALITY_SENSOR_WIFI_RECONNECT_DELAY_SECONDS
+#define AIR_QUALITY_SENSOR_WIFI_RECONNECT_DELAY_SECONDS 60
+#endif
+
 // Defines the number of AIR_QUALITY_SENSOR_UPDATE_SECONDS cycle that must occur between
 // each data transmission to the TELEMETRY_URL. Has no net effect if TELEMETRY_URL is
 // a nullptr. When transmitting data, only the measurement from the current cycle is

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,9 @@ void setup()
   Serial.begin(9600);
   // wait some time for the serial conenction to stabilize.
   delay(500);
-  Serial.println(F("\nStarting DIY Air Quality Monitor ..."));
+  Serial.print(F("\nStarting DIY Air Quality Monitor ("));
+  Serial.print(F(SENSOR_NAME));
+  Serial.println(F(")..."));
   Application::getInstance()->setup();
 }
 


### PR DESCRIPTION
This change ensures that the main loop will attempt a wifi reconnection,
once every 60 seconds (by default) if it disconnects. Previously, if you
didn't have the JSON upload feature enabled it would never reconnect to
an AP that it got disconnected from.

 Please enter the commit message for your changes. Lines starting